### PR TITLE
Refactor config structure and implement agent status management

### DIFF
--- a/examples/agent_pool/config.yaml
+++ b/examples/agent_pool/config.yaml
@@ -1,40 +1,38 @@
 # Agent Pool Example Configuration
 # 
-# This example demonstrates basic agent pool functionality:
-# - 2 agents running in parallel on different ports
-# - Simple tasks distributed across agents automatically
+# This example demonstrates agent pool functionality:
+# - 2 agents running in parallel on different ports  
+# - Tasks distributed across available idle agents
 #
-# Usage: cargo run -- --rules examples/agent_pool/concurrency_demo.yaml
+# Usage: cargo run -- --config examples/agent_pool/config.yaml
 
 # Web UI configuration
 web_ui:
   enabled: true
   host: "localhost"
   base_port: 9990     # First agent on port 9990
-
-# Agent configuration
-agents:
-  concurrency: 2      # 2 agents: 9990, 9991
   cols: 80
   rows: 24
 
-entries:
-  # Task A - will go to agent 1
-  - name: "task_a"
-    trigger: "periodic"
-    interval: "3s"
-    action: "send_keys"
-    keys: ["bash examples/agent_pool/simple_task.sh A", "\r"]
+# Agent configuration
+agents:
+  pool: 2      # 2 agents: 9990, 9991
+  
+  triggers:
+    # Task A - will go to first available idle agent
+    - name: "task_a"
+      event: "timer:3s"
+      action: "send_keys"
+      keys: ["bash examples/agent_pool/simple_task.sh A", "\r"]
 
-  # Task B - will go to agent 2  
-  - name: "task_b"
-    trigger: "periodic"
-    interval: "4s"
-    action: "send_keys"
-    keys: ["bash examples/agent_pool/simple_task.sh B", "\r"]
+    # Task B - will go to first available idle agent  
+    - name: "task_b"
+      event: "timer:4s"
+      action: "send_keys"
+      keys: ["bash examples/agent_pool/simple_task.sh B", "\r"]
 
-rules:
-  # React to task completion
-  - pattern: "Task (\\w+) completed"
-    action: "send_keys"
-    keys: ["echo 'Acknowledged task ${1}'", "\r"]
+  rules:
+    # React to task completion
+    - when: "Task (\\w+) completed"
+      action: "send_keys"
+      keys: ["echo 'Acknowledged task ${1}'", "\r"]

--- a/examples/basic/config.yaml
+++ b/examples/basic/config.yaml
@@ -1,19 +1,30 @@
-# Entry and Rule definitions for agent automation
+# Basic agent automation configuration
 
-# External triggers - initiated by user commands
-entries:
-  - name: "start_mock"
-    trigger: "on_start"
-    action: "send_keys"
-    keys: ["bash examples/basic/mock.sh", "\r"]
+# Web UI settings
+web_ui:
+  enabled: true
+  host: "localhost"
+  base_port: 9990
+  cols: 80
+  rows: 24
 
-# Automatic detection rules - triggered by terminal state changes
-# Higher priority = earlier in the list (line order matters)
-rules:
-  - pattern: "Do you want to proceed"
-    action: "send_keys"
-    keys: ["1", "\r"]
-    
-  - pattern: "^exit$"
-    action: "send_keys"
-    keys: ["/exit", "\r"]
+# Agent configuration and automation
+agents:
+  pool: 1
+  
+  # Triggers for starting automation
+  triggers:
+    - name: "start_mock"
+      event: "startup"
+      action: "send_keys"
+      keys: ["bash examples/basic/mock.sh", "\r"]
+  
+  # Rules for responding to terminal output
+  rules:
+    - when: "Do you want to proceed"
+      action: "send_keys"
+      keys: ["1", "\r"]
+      
+    - when: "^exit$"
+      action: "send_keys"
+      keys: ["/exit", "\r"]

--- a/examples/claude/config.yaml
+++ b/examples/claude/config.yaml
@@ -1,32 +1,31 @@
-# Entry and Rule definitions for agent automation
+# Configuration for agent automation with Claude
 
-# Web UI configuration
+# Web UI configuration - includes display settings
 web_ui:
   enabled: true
   host: "localhost"
   base_port: 9990
-
-# Agent configuration
-agents:
-  concurrency: 1
   cols: 120
   rows: 40
 
-# External triggers - initiated by user commands
-entries:
-  - name: "claude"
-    trigger: "on_start"
-    action: "send_keys"
-    keys: ["claude 'say hello, in Japanese'", "\r"]
-
-# Automatic detection rules - triggered by terminal state changes
-# Higher priority = earlier in the list (line order matters)
-rules:
-  - pattern: "Do you want to proceed"
-    action: "send_keys"
-    keys: ["1", "\r"]
-    
-  # Match Claude's response when it starts generating text
-  - pattern: "こんにちは"
-    action: "send_keys"
-    keys: ["/exit", "\r"]
+# Agent configuration and automation rules
+agents:
+  pool: 1  # Number of agents in the pool
+  
+  # Triggers monitored in Idle state
+  triggers:
+    - name: "claude"
+      event: "startup"
+      action: "send_keys"
+      keys: ["claude 'say hello, in Japanese'", "\r"]
+  
+  # Rules monitored in Active state
+  rules:
+    - when: "Do you want to proceed"
+      action: "send_keys"
+      keys: ["1", "\r"]
+      
+    # Match Claude's response when it starts generating text
+    - when: "こんにちは"
+      action: "send_keys"
+      keys: ["/exit", "\r"]

--- a/examples/dedupe_queue/config.yaml
+++ b/examples/dedupe_queue/config.yaml
@@ -6,44 +6,55 @@
 # 3. In-memory deduplication prevents duplicate processing
 # 4. Automatic queue processing with <task> variable expansion
 #
-# Usage: cargo run -- --rules examples/dedupe_queue/dedupe_example.yaml
+# Usage: cargo run -- --config examples/dedupe_queue/config.yaml
 
-entries:
-  # 1. Periodic Item Generation with Deduplication
-  # Executes generate_items.sh every 8 seconds and adds ONLY unique results to pending_items queue
-  - name: "item_generator"
-    trigger: "periodic"
-    interval: "8s"
-    action: "enqueue_dedupe"
-    queue: "pending_items"
-    command: "bash examples/dedupe_queue/generate_items.sh"
+# Web UI configuration
+web_ui:
+  enabled: true
+  host: "localhost"
+  base_port: 9990
+  cols: 80
+  rows: 24
 
-  # 2. Dedupe Queue Processing
-  # Processes each unique item when it's added to the pending_items queue
-  # Uses <task> placeholder which gets replaced with the actual item value
-  - name: "item_processor"
-    trigger: "enqueue:pending_items"
-    action: "send_keys"
-    keys: ["echo 'Processing unique: <task>'", "\r", "bash examples/dedupe_queue/process_item.sh <task>", "\r"]
+# Agent configuration
+agents:
+  pool: 1
+  
+  triggers:
+    # 1. Periodic Item Generation with Deduplication
+    # Executes generate_items.sh every 8 seconds and adds ONLY unique results to pending_items queue
+    - name: "item_generator"
+      event: "timer:8s"
+      action: "enqueue_dedupe"
+      queue: "pending_items"
+      command: "bash examples/dedupe_queue/generate_items.sh"
 
-  # 3. Completed Item Logging
-  # Processes completed items for logging
-  - name: "completed_logger"
-    trigger: "enqueue:completed_items"
-    action: "send_keys"
-    keys: ["echo 'Logged unique: <task>'", "\r"]
+    # 2. Dedupe Queue Processing
+    # Processes each unique item when it's added to the pending_items queue
+    # Uses <task> placeholder which gets replaced with the actual item value
+    - name: "item_processor"
+      event: "queue:pending_items"
+      action: "send_keys"
+      keys: ["echo 'Processing unique: <task>'", "\r", "bash examples/dedupe_queue/process_item.sh <task>", "\r"]
 
-rules:
-  # 4. Rule-based Enqueuing for Completed Items
-  # When item processing shows "Status: processed", capture and log it
-  - pattern: "Status: processed"
-    action: "enqueue"
-    queue: "completed_items"
-    command: "echo 'Item completed at: $(date)'"
+    # 3. Completed Item Logging
+    # Processes completed items for logging
+    - name: "completed_logger"
+      event: "queue:completed_items"
+      action: "send_keys"
+      keys: ["echo 'Logged unique: <task>'", "\r"]
 
-  # 5. Capture Processed Items with Variables
-  # Captures specific item IDs from output and processes them
-  - pattern: "Processing unique item: (item-\\d+)"
-    action: "enqueue"
-    queue: "processed_items"
-    command: "echo 'Processed: ${1}'"
+  rules:
+    # 4. Rule-based Enqueuing for Completed Items
+    # When item processing shows "Status: processed", capture and log it
+    - when: "Status: processed"
+      action: "enqueue"
+      queue: "completed_items"
+      command: "echo 'Item completed at: $(date)'"
+
+    # 5. Capture Processed Items with Variables
+    # Captures specific item IDs from output and processes them
+    - when: "Processing unique item: (item-\\d+)"
+      action: "enqueue"
+      queue: "processed_items"
+      command: "echo 'Processed: ${1}'"

--- a/examples/simple_queue/config.yaml
+++ b/examples/simple_queue/config.yaml
@@ -1,19 +1,32 @@
 # Simple Queue Demo
 #
 # A minimal example showing periodic task generation and processing
-# Usage: cargo run -- --rules examples/simple_queue/simple_queue.yaml
+# Usage: cargo run -- --config examples/simple_queue/config.yaml
 
-entries:
-  # Generate tasks every 15 seconds
-  - name: "generate_tasks"
-    trigger: "periodic"
-    interval: "15s"
-    action: "enqueue"
-    queue: "tasks"
-    command: "bash examples/simple_queue/list_tasks.sh"
+# Web UI configuration
+web_ui:
+  enabled: true
+  host: "localhost"
+  base_port: 9990
+  cols: 80
+  rows: 24
 
-  # Process each task automatically
-  - name: "process_tasks"
-    trigger: "enqueue:tasks"
-    action: "send_keys"
-    keys: ["bash examples/simple_queue/process_task.sh <task>", "\r"]
+# Agent configuration
+agents:
+  pool: 1
+  
+  triggers:
+    # Generate tasks every 15 seconds
+    - name: "generate_tasks"
+      event: "timer:15s"
+      action: "enqueue"
+      queue: "tasks"
+      command: "bash examples/simple_queue/list_tasks.sh"
+
+    # Process each task automatically
+    - name: "process_tasks"
+      event: "queue:tasks"
+      action: "send_keys"
+      keys: ["bash examples/simple_queue/process_task.sh <task>", "\r"]
+  
+  rules: []

--- a/examples/web-ui/config.yaml
+++ b/examples/web-ui/config.yaml
@@ -1,27 +1,27 @@
 # Example configuration with Web UI enabled
 # This shows how to configure the web terminal interface
 
-# Web UI configuration
+# Web UI configuration - includes terminal display settings
 web_ui:
   enabled: true          # Enable/disable web interface
   host: "localhost"      # Bind address (use "0.0.0.0" for external access)
   base_port: 9990        # First agent web interface port
-
-# Agent configuration
-agents:
-  concurrency: 2         # Number of agents (get sequential ports: 9990, 9991)
   cols: 120              # Terminal width for all agents
   rows: 40               # Terminal height for all agents
 
-# Example entries for automation
-entries:
-  - name: "compound_command_test"
-    trigger: "on_start"
-    action: "send_keys"
-    keys: ["ls --color=always", "\r"]
+# Agent configuration and automation
+agents:
+  pool: 2                # Number of agents (get sequential ports: 9990, 9991)
+  
+  # Example triggers for automation
+  triggers:
+    - name: "compound_command_test"
+      event: "startup"
+      action: "send_keys"
+      keys: ["ls --color=always", "\r"]
 
-# Example rules for pattern matching
-rules:
-  - pattern: "Web UI ready"
-    action: "send_keys"
-    keys: ["echo 'UI is ready'", "\r"]
+  # Example rules for pattern matching
+  rules:
+    - when: "Web UI ready"
+      action: "send_keys"
+      keys: ["echo 'UI is ready'", "\r"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,18 @@ use tokio::signal;
 use tokio::time::interval;
 use web_server::WebServer;
 
+/// Check if the terminal output indicates return to bash prompt
+fn is_back_to_bash(output: &str) -> bool {
+    // Basic patterns that indicate return to bash
+    // This is a simple heuristic and may need refinement
+    output.contains("$ ")
+        || output.contains("% ")
+        || output.contains("> ")
+        || output.ends_with("$ ")
+        || output.ends_with("% ")
+        || output.ends_with("> ")
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Parse command line arguments first to get debug flag
@@ -116,8 +128,15 @@ async fn run_automation_command(rules_path: PathBuf) -> Result<()> {
     if !on_start_entries.is_empty() {
         println!("🎬 Executing on_start entries...");
         for entry in on_start_entries {
-            let agent = agent_pool.get_agent();
-            execute_entry_action(&agent, &entry, &queue_manager).await?;
+            if let Some(agent) = agent_pool.get_idle_agent().await {
+                agent.set_status(agent::AgentStatus::Active).await;
+                execute_entry_action(&agent, &entry, &queue_manager).await?;
+            } else {
+                println!(
+                    "⚠️ No idle agent available for startup entry: {}",
+                    entry.name
+                );
+            }
         }
     }
 
@@ -135,14 +154,21 @@ async fn run_automation_command(rules_path: PathBuf) -> Result<()> {
                 loop {
                     timer.tick().await;
                     println!("⏰ Executing periodic entry: {}", entry_clone.name);
-                    let agent = agent_pool_clone.get_agent();
-                    if let Err(e) =
-                        execute_periodic_entry(&entry_clone, &queue_manager_clone, Some(&agent))
-                            .await
-                    {
-                        eprintln!(
-                            "❌ Error executing periodic entry '{}': {}",
-                            entry_clone.name, e
+                    if let Some(agent) = agent_pool_clone.get_idle_agent().await {
+                        agent.set_status(agent::AgentStatus::Active).await;
+                        if let Err(e) =
+                            execute_periodic_entry(&entry_clone, &queue_manager_clone, Some(&agent))
+                                .await
+                        {
+                            eprintln!(
+                                "❌ Error executing periodic entry '{}': {}",
+                                entry_clone.name, e
+                            );
+                        }
+                    } else {
+                        println!(
+                            "⚠️ No idle agent available for periodic entry: {}",
+                            entry_clone.name
                         );
                     }
                 }
@@ -183,13 +209,21 @@ async fn run_automation_command(rules_path: PathBuf) -> Result<()> {
                     let resolved_entry = resolve_entry_task_placeholders(&entry_clone, &task_item);
 
                     // Execute the entry action with resolved placeholders
-                    let agent = agent_pool_clone.get_agent();
-                    if let Err(e) =
-                        execute_entry_action(&agent, &resolved_entry, &queue_manager_clone).await
-                    {
+                    if let Some(agent) = agent_pool_clone.get_idle_agent().await {
+                        agent.set_status(agent::AgentStatus::Active).await;
+                        if let Err(e) =
+                            execute_entry_action(&agent, &resolved_entry, &queue_manager_clone)
+                                .await
+                        {
+                            println!(
+                                "❌ Error executing queue entry '{}': {}",
+                                resolved_entry.name, e
+                            );
+                        }
+                    } else {
                         println!(
-                            "❌ Error executing queue entry '{}': {}",
-                            resolved_entry.name, e
+                            "⚠️ No idle agent available for queue entry: {}",
+                            resolved_entry.name
                         );
                     }
                 }
@@ -198,38 +232,47 @@ async fn run_automation_command(rules_path: PathBuf) -> Result<()> {
         }
     }
 
-    // Start PTY output monitoring tasks for each agent
+    // Start state-based monitoring loop
     let ruler = Arc::new(ruler); // Wrap ruler in Arc for sharing
-    let mut pty_monitor_handles = Vec::new();
-    for i in 0..agent_pool.size() {
-        let agent = agent_pool.get_agent_by_index(i);
-        let ruler_clone = Arc::clone(&ruler);
-        let queue_manager_clone = queue_manager.clone();
+    let agent_pool_for_monitoring = Arc::clone(&agent_pool);
+    let ruler_for_monitoring = Arc::clone(&ruler);
+    let queue_manager_for_monitoring = queue_manager.clone();
 
-        let handle = tokio::spawn(async move {
-            tracing::debug!("🔍 Starting PTY monitor task for agent {}", i);
+    let monitoring_handle = tokio::spawn(async move {
+        loop {
+            // Monitor active agents for rule matching
+            let active_agents = agent_pool_for_monitoring.get_active_agents().await;
+            for agent in active_agents {
+                // Get PTY output receiver
+                if let Ok(mut rx) = agent.get_pty_output_receiver().await {
+                    // Check for new output (non-blocking)
+                    if let Ok(pty_output) = rx.try_recv() {
+                        // Check if agent returned to bash (basic detection)
+                        if is_back_to_bash(&pty_output) {
+                            agent.set_status(agent::AgentStatus::Idle).await;
+                            tracing::debug!("🔄 Agent {} returned to Idle", agent.get_id());
+                            continue;
+                        }
 
-            // Get PTY output receiver
-            if let Ok(mut rx) = agent.get_pty_output_receiver().await {
-                tracing::debug!("✅ Got PTY receiver for agent {}", i);
-
-                // Continuously monitor PTY output
-                while let Ok(pty_output) = rx.recv().await {
-                    if let Err(e) =
-                        process_pty_output(&pty_output, &agent, &ruler_clone, &queue_manager_clone)
-                            .await
-                    {
-                        tracing::debug!("❌ Error processing PTY output: {}", e);
+                        // Process rules for active agents
+                        if let Err(e) = process_pty_output(
+                            &pty_output,
+                            &agent,
+                            &ruler_for_monitoring,
+                            &queue_manager_for_monitoring,
+                        )
+                        .await
+                        {
+                            tracing::debug!("❌ Error processing PTY output: {}", e);
+                        }
                     }
                 }
-
-                tracing::debug!("❌ PTY monitor task ended for agent {}", i);
-            } else {
-                tracing::debug!("❌ Failed to get PTY receiver for agent {}", i);
             }
-        });
-        pty_monitor_handles.push(handle);
-    }
+
+            // Small delay to prevent busy waiting
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+    });
 
     tokio::select! {
         _ = signal::ctrl_c() => {
@@ -260,9 +303,7 @@ async fn run_automation_command(rules_path: PathBuf) -> Result<()> {
     for handle in web_server_handles {
         handle.abort();
     }
-    for handle in pty_monitor_handles {
-        handle.abort();
-    }
+    monitoring_handle.abort();
 
     println!("🧹 Shutting down...");
 
@@ -282,9 +323,9 @@ async fn handle_show_command(args: &cli::ShowArgs) -> Result<()> {
     println!("  host: {}", monitor_config.web_ui.host);
     println!("  base_port: {}", monitor_config.web_ui.base_port);
     println!("\nAgents config:");
-    println!("  concurrency: {}", monitor_config.agents.concurrency);
-    println!("  cols: {}", monitor_config.agents.cols);
-    println!("  rows: {}", monitor_config.agents.rows);
+    println!("  pool: {}", monitor_config.agents.pool);
+    println!("  cols: {}", monitor_config.web_ui.cols);
+    println!("  rows: {}", monitor_config.web_ui.rows);
 
     if !entries.is_empty() {
         println!("\nEntries:");

--- a/src/ruler/rule.rs
+++ b/src/ruler/rule.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 // YAML structure for loading rules
 #[derive(Debug, Deserialize)]
 pub struct Rule {
-    pub pattern: String,
+    #[serde(alias = "pattern")]
+    pub when: String,
     #[serde(default)]
     pub action: Option<String>,
     #[serde(default)]
@@ -30,8 +31,8 @@ pub struct CompiledRule {
 
 impl Rule {
     pub fn compile(&self) -> Result<CompiledRule> {
-        let regex = Regex::new(&self.pattern)
-            .with_context(|| format!("Invalid regex pattern: {}", self.pattern))?;
+        let regex = Regex::new(&self.when)
+            .with_context(|| format!("Invalid regex pattern: {}", self.when))?;
 
         let action = compile_action(
             &self.action,

--- a/src/web_server/tests.rs
+++ b/src/web_server/tests.rs
@@ -34,7 +34,7 @@ fn test_monitor_config_with_web_ui() {
     assert!(config.web_ui.enabled);
     assert_eq!(config.web_ui.host, "localhost");
     assert_eq!(config.web_ui.base_port, 9990);
-    assert_eq!(config.agents.concurrency, 1);
+    assert_eq!(config.agents.pool, 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This PR implements a major refactoring of the configuration structure and introduces agent status management as discussed in #78.

### Config Structure Changes
- **Moved terminal dimensions**: `cols`/`rows` moved from `agents` to `web_ui` section (more logical placement)
- **Renamed fields**: `concurrency` → `pool`, `trigger` → `event`, `pattern` → `when`
- **Restructured hierarchy**: `entries` and `rules` now under `agents` section
- **Simplified syntax**: `timer:30s` instead of separate `interval` field, `queue:tasks` instead of `enqueue:tasks`

### Agent Status Management
- **Added AgentStatus enum**: `Idle` (monitoring triggers) and `Active` (executing tasks and monitoring rules)
- **State-based selection**: Replaced round-robin with idle agent selection
- **Automatic state transitions**: Agents automatically return to `Idle` when bash prompt is detected
- **Resource management**: Prevents conflicts through proper state tracking

### Monitoring Logic Improvements
- **Idle state**: Agents monitor triggers for new task assignments
- **Active state**: Agents monitor rules and detect bash prompt for state transition
- **Better resource utilization**: Only idle agents receive new tasks

### Configuration Examples
- Updated all example configs to new structure
- Maintained backward compatibility through serde aliases
- Improved documentation and comments

## Test plan
- [x] All existing tests pass
- [x] Cargo clippy passes with no warnings
- [x] Code formatting is correct
- [x] Pre-commit hooks pass
- [x] Configuration examples updated and validated

## Breaking Changes
This is a breaking change for configuration files, but since the project is not yet released, backward compatibility is handled through serde aliases where possible.

### Before
```yaml
agents:
  concurrency: 2
  cols: 80
  rows: 24

entries:
  - name: "task"
    trigger: "periodic"
    interval: "30s"
    action: "send_keys"
    keys: ["echo test", "\r"]

rules:
  - pattern: "Continue?"
    action: "send_keys"
    keys: ["y", "\r"]
```

### After
```yaml
web_ui:
  enabled: true
  host: "localhost"
  base_port: 9990
  cols: 80
  rows: 24

agents:
  pool: 2
  
  triggers:
    - name: "task"
      event: "timer:30s"
      action: "send_keys"
      keys: ["echo test", "\r"]
  
  rules:
    - when: "Continue?"
      action: "send_keys"
      keys: ["y", "\r"]
```

Closes #78

🤖 Generated with [Claude Code](https://claude.ai/code)