### PR TITLE
Agent becomes Active even when trigger conditions are not met

### DIFF
--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -6,6 +6,35 @@ use std::collections::HashSet;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Check if a periodic entry will produce data to process
+pub async fn has_data_to_process(entry: &ruler::entry::CompiledEntry) -> Result<bool> {
+    // If there's no source command, we consider it as having data to process
+    if entry.source.is_none() {
+        return Ok(true);
+    }
+
+    if let Some(source) = &entry.source {
+        // Execute the source command
+        let output = Command::new("sh").arg("-c").arg(source).output()?;
+
+        if !output.status.success() {
+            return Ok(false);
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let lines: Vec<String> = stdout
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|s| s.to_string())
+            .collect();
+
+        // Return true if we have any lines to process
+        Ok(!lines.is_empty())
+    } else {
+        Ok(true)
+    }
+}
+
 /// Execute a periodic entry action (with agent context)
 pub async fn execute_periodic_entry(
     entry: &ruler::entry::CompiledEntry,
@@ -333,4 +362,107 @@ pub async fn process_pty_output(
 fn strip_ansi_escapes(text: &str) -> String {
     let ansi_regex = regex::Regex::new(r"\x1b\[[0-9;]*[mGKHF]").unwrap();
     ansi_regex.replace_all(text, "").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ruler::entry::{CompiledEntry, TriggerType};
+    use crate::ruler::types::ActionType;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_has_data_to_process_with_no_source() {
+        // Create a compiled entry without a source command
+        let entry = CompiledEntry {
+            name: "test_entry".to_string(),
+            trigger: TriggerType::Periodic {
+                interval: Duration::from_secs(10),
+            },
+            source: None,
+            action: ActionType::SendKeys(vec!["echo test".to_string()]),
+            dedupe: false,
+        };
+
+        // Should return true for entries without source commands
+        let result = has_data_to_process(&entry).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_has_data_to_process_with_empty_source() {
+        // Create a compiled entry with a source command that returns empty output
+        let entry = CompiledEntry {
+            name: "test_entry".to_string(),
+            trigger: TriggerType::Periodic {
+                interval: Duration::from_secs(10),
+            },
+            source: Some("true".to_string()), // true command produces no output
+            action: ActionType::SendKeys(vec!["echo test".to_string()]),
+            dedupe: false,
+        };
+
+        // Should return false for source commands that produce no output
+        let result = has_data_to_process(&entry).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_has_data_to_process_with_data() {
+        // Create a compiled entry with a source command that returns data
+        let entry = CompiledEntry {
+            name: "test_entry".to_string(),
+            trigger: TriggerType::Periodic {
+                interval: Duration::from_secs(10),
+            },
+            source: Some("echo 'test line'".to_string()),
+            action: ActionType::SendKeys(vec!["echo test".to_string()]),
+            dedupe: false,
+        };
+
+        // Should return true for source commands that produce output
+        let result = has_data_to_process(&entry).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_has_data_to_process_with_whitespace_only() {
+        // Create a compiled entry with a source command that returns only whitespace
+        let entry = CompiledEntry {
+            name: "test_entry".to_string(),
+            trigger: TriggerType::Periodic {
+                interval: Duration::from_secs(10),
+            },
+            source: Some("echo '   '".to_string()), // Only whitespace
+            action: ActionType::SendKeys(vec!["echo test".to_string()]),
+            dedupe: false,
+        };
+
+        // Should return false for source commands that produce only whitespace
+        let result = has_data_to_process(&entry).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_has_data_to_process_with_failing_command() {
+        // Create a compiled entry with a source command that fails
+        let entry = CompiledEntry {
+            name: "test_entry".to_string(),
+            trigger: TriggerType::Periodic {
+                interval: Duration::from_secs(10),
+            },
+            source: Some("false".to_string()), // Command that always fails
+            action: ActionType::SendKeys(vec!["echo test".to_string()]),
+            dedupe: false,
+        };
+
+        // Should return false for failing commands
+        let result = has_data_to_process(&entry).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,26 +143,49 @@ async fn run_automation_command(rules_path: PathBuf) -> Result<()> {
                 loop {
                     timer.tick().await;
                     println!("⏰ Executing periodic entry: {}", entry_clone.name);
-                    if let Some(agent) = agent_pool_clone.get_idle_agent().await {
-                        println!(
-                            "🔄 Setting agent {} to Active for periodic entry",
-                            agent.get_id()
-                        );
-                        agent.set_status(agent::AgentStatus::Active).await;
-                        if let Err(e) =
-                            execute_periodic_entry(&entry_clone, &queue_manager_clone, Some(&agent))
+
+                    // Check if there's data to process before setting agent to Active
+                    match cli::has_data_to_process(&entry_clone).await {
+                        Ok(true) => {
+                            // Only proceed if there's data to process
+                            if let Some(agent) = agent_pool_clone.get_idle_agent().await {
+                                println!(
+                                    "🔄 Setting agent {} to Active for periodic entry",
+                                    agent.get_id()
+                                );
+                                agent.set_status(agent::AgentStatus::Active).await;
+                                if let Err(e) = execute_periodic_entry(
+                                    &entry_clone,
+                                    &queue_manager_clone,
+                                    Some(&agent),
+                                )
                                 .await
-                        {
+                                {
+                                    eprintln!(
+                                        "❌ Error executing periodic entry '{}': {}",
+                                        entry_clone.name, e
+                                    );
+                                }
+                            } else {
+                                println!(
+                                    "⚠️ No idle agent available for periodic entry: {}",
+                                    entry_clone.name
+                                );
+                            }
+                        }
+                        Ok(false) => {
+                            // No data to process, agent remains idle
+                            println!(
+                                "ℹ️ No data to process for periodic entry: {}",
+                                entry_clone.name
+                            );
+                        }
+                        Err(e) => {
                             eprintln!(
-                                "❌ Error executing periodic entry '{}': {}",
+                                "❌ Error checking data for periodic entry '{}': {}",
                                 entry_clone.name, e
                             );
                         }
-                    } else {
-                        println!(
-                            "⚠️ No idle agent available for periodic entry: {}",
-                            entry_clone.name
-                        );
                     }
                 }
             });


### PR DESCRIPTION
Closes #100

## Summary
Fixed issue where agents become Active even when source commands return 0 lines, preventing periodic triggers from executing properly.

## Problem
- Agent was set to Active state regardless of whether source command produces data
- When source command returns 0 lines, agent should remain Idle to allow continued periodic execution
- This blocked subsequent periodic trigger executions with "No idle agent available" messages

## Solution
- **Added has_data_to_process() helper function**: Checks if source command produces actual data before setting agent to Active
- **Modified periodic trigger logic**: Only proceeds with agent activation when there's data to process
- **Enhanced logging**: Added informative message when no data is available
- **Proper error handling**: Handles source command failures gracefully

## Key Changes
1. **src/cli/helpers.rs**: Added has_data_to_process() function with comprehensive logic for:
   - Entries without source commands (returns true)
   - Empty command output (returns false) 
   - Commands that fail (returns false)
   - Whitespace-only output (returns false)

2. **src/main.rs**: Updated periodic trigger loop to:
   - Check data availability before agent activation
   - Only set agent to Active when there's actual work to do
   - Maintain periodic execution when no data is available

## Test Coverage
Added 5 comprehensive test cases covering:
- Entries without source commands
- Commands producing no output
- Commands producing actual data
- Commands producing only whitespace
- Commands that fail

## Expected Behavior After Fix
- Agent remains Idle when source command returns 0 lines
- Periodic triggers continue to execute regularly
- Actions are only executed when there is actual data to process
- No more "No idle agent available" blocking messages when no data is available

All tests pass and code quality checks (clippy, fmt) are satisfied.